### PR TITLE
Change derivative request API to conform with OpenMM

### DIFF
--- a/openmmapi/include/SlicedNonbondedForce.h
+++ b/openmmapi/include/SlicedNonbondedForce.h
@@ -7,7 +7,7 @@
  *                                                                            *
  * An OpenMM plugin for slicing nonbonded potential energy calculations.      *
  *                                                                            *
- * Copyright (c) 2022 Charlles Abreu                                          *
+ * Copyright (c) 2022-2025 Charlles Abreu                                     *
  * https://github.com/craabreu/openmm-nonbonded-slicing                       *
  * -------------------------------------------------------------------------- */
 
@@ -40,17 +40,17 @@ public:
     int getNumScalingParameters() const {
         return scalingParameters.size();
     }
-    int getNumScalingParameterDerivatives() const {
-        return scalingParameterDerivatives.size();
+    int getNumEnergyParameterDerivatives() const {
+        return EnergyParameterDerivatives.size();
     }
     void setParticleSubset(int index, int subset);
     int getParticleSubset(int index) const;
     int addScalingParameter(const string& parameter, int subset1, int subset2, bool includeCoulomb, bool includeLJ);
     void getScalingParameter(int index, string& parameter, int& subset1, int& subset2, bool& includeCoulomb, bool& includeLJ) const;
     void setScalingParameter(int index, const string& parameter, int subset1, int subset2, bool includeCoulomb, bool includeLJ);
-    int addScalingParameterDerivative(const string& parameter);
-    const string& getScalingParameterDerivativeName(int index) const;
-    void setScalingParameterDerivative(int index, const string& parameter);
+    int addEnergyParameterDerivative(const string& parameter);
+    const string& getEnergyParameterDerivativeName(int index) const;
+    void setEnergyParameterDerivative(int index, const string& parameter);
     bool getUseCuFFT() const {
         return useCuFFT;
     };
@@ -66,7 +66,7 @@ private:
     int numSubsets;
     map<int, int> subsets;
     vector<ScalingParameterInfo> scalingParameters;
-    vector<int> scalingParameterDerivatives;
+    vector<int> EnergyParameterDerivatives;
     bool useCuFFT;
 };
 

--- a/openmmapi/include/SlicedNonbondedForce.h
+++ b/openmmapi/include/SlicedNonbondedForce.h
@@ -50,7 +50,6 @@ public:
     void setScalingParameter(int index, const string& parameter, int subset1, int subset2, bool includeCoulomb, bool includeLJ);
     int addEnergyParameterDerivative(const string& parameter);
     const string& getEnergyParameterDerivativeName(int index) const;
-    void setEnergyParameterDerivative(int index, const string& parameter);
     bool getUseCuFFT() const {
         return useCuFFT;
     };

--- a/openmmapi/include/SlicedNonbondedForce.h
+++ b/openmmapi/include/SlicedNonbondedForce.h
@@ -41,7 +41,7 @@ public:
         return scalingParameters.size();
     }
     int getNumEnergyParameterDerivatives() const {
-        return EnergyParameterDerivatives.size();
+        return energyParameterDerivatives.size();
     }
     void setParticleSubset(int index, int subset);
     int getParticleSubset(int index) const;
@@ -66,7 +66,7 @@ private:
     int numSubsets;
     map<int, int> subsets;
     vector<ScalingParameterInfo> scalingParameters;
-    vector<int> EnergyParameterDerivatives;
+    vector<int> energyParameterDerivatives;
     bool useCuFFT;
 };
 

--- a/openmmapi/src/SlicedNonbondedForce.cpp
+++ b/openmmapi/src/SlicedNonbondedForce.cpp
@@ -161,31 +161,31 @@ int SlicedNonbondedForce::getScalingParameterIndex(const string& parameter) cons
     throw OpenMMException("There is no scaling parameter called '"+parameter+"'");
 }
 
-int SlicedNonbondedForce::addScalingParameterDerivative(const string& parameter) {
+int SlicedNonbondedForce::addEnergyParameterDerivative(const string& parameter) {
     int scalingParameterIndex = getScalingParameterIndex(parameter);
-    auto begin = scalingParameterDerivatives.begin();
-    auto end = scalingParameterDerivatives.end();
+    auto begin = energyParameterDerivatives.begin();
+    auto end = energyParameterDerivatives.end();
     if (find(begin, end, scalingParameterIndex) != end)
         throwException(__FILE__, __LINE__, "This scaling parameter derivative has already been requested");
-    scalingParameterDerivatives.push_back(scalingParameterIndex);
-    return scalingParameterDerivatives.size()-1;
+    energyParameterDerivatives.push_back(scalingParameterIndex);
+    return energyParameterDerivatives.size()-1;
 }
 
-const string& SlicedNonbondedForce::getScalingParameterDerivativeName(int index) const {
-    ASSERT_VALID("Index", index, scalingParameterDerivatives.size());
-    int globalParamIndex = scalingParameters[scalingParameterDerivatives[index]].globalParamIndex;
+const string& SlicedNonbondedForce::getEnergyParameterDerivativeName(int index) const {
+    ASSERT_VALID("Index", index, energyParameterDerivatives.size());
+    int globalParamIndex = scalingParameters[energyParameterDerivatives[index]].globalParamIndex;
     return getGlobalParameterName(globalParamIndex);
 }
 
-void SlicedNonbondedForce::setScalingParameterDerivative(int index, const string& parameter) {
-    ASSERT_VALID("Index", index, scalingParameterDerivatives.size());
+void SlicedNonbondedForce::setEnergyParameterDerivative(int index, const string& parameter) {
+    ASSERT_VALID("Index", index, energyParameterDerivatives.size());
     int scalingParameterIndex = getScalingParameterIndex(parameter);
-    if (scalingParameterDerivatives[index] != scalingParameterIndex) {
-        auto begin = scalingParameterDerivatives.begin();
-        auto end = scalingParameterDerivatives.end();
+    if (energyParameterDerivatives[index] != scalingParameterIndex) {
+        auto begin = energyParameterDerivatives.begin();
+        auto end = energyParameterDerivatives.end();
         if (find(begin, end, scalingParameterIndex) != end)
             throwException(__FILE__, __LINE__, "This scaling parameter derivative has already been requested");
-        scalingParameterDerivatives[index] = scalingParameterIndex;
+        energyParameterDerivatives[index] = scalingParameterIndex;
     }
 }
 

--- a/openmmapi/src/SlicedNonbondedForce.cpp
+++ b/openmmapi/src/SlicedNonbondedForce.cpp
@@ -177,18 +177,6 @@ const string& SlicedNonbondedForce::getEnergyParameterDerivativeName(int index) 
     return getGlobalParameterName(globalParamIndex);
 }
 
-void SlicedNonbondedForce::setEnergyParameterDerivative(int index, const string& parameter) {
-    ASSERT_VALID("Index", index, energyParameterDerivatives.size());
-    int scalingParameterIndex = getScalingParameterIndex(parameter);
-    if (energyParameterDerivatives[index] != scalingParameterIndex) {
-        auto begin = energyParameterDerivatives.begin();
-        auto end = energyParameterDerivatives.end();
-        if (find(begin, end, scalingParameterIndex) != end)
-            throwException(__FILE__, __LINE__, "This scaling parameter derivative has already been requested");
-        energyParameterDerivatives[index] = scalingParameterIndex;
-    }
-}
-
 ForceImpl* SlicedNonbondedForce::createImpl() const {
     return new SlicedNonbondedForceImpl(*this);
 }

--- a/platforms/common/src/CommonNonbondedSlicingKernels.cpp
+++ b/platforms/common/src/CommonNonbondedSlicingKernels.cpp
@@ -280,10 +280,10 @@ void CommonCalcSlicedNonbondedForceKernel::commonInitialize(
     subsets.initialize<int>(cc, cc.getPaddedNumAtoms(), "subsets");
     subsets.upload(subsetsVec);
 
-    int numDerivs = force.getNumScalingParameterDerivatives();
+    int numDerivs = force.getNumEnergyParameterDerivatives();
     hasDerivatives = numDerivs > 0;
     for (int i = 0; i < numDerivs; i++)
-        requestedDerivatives.insert(force.getScalingParameterDerivativeName(i));
+        requestedDerivatives.insert(force.getEnergyParameterDerivativeName(i));
 
     for (int index = 0; index < force.getNumScalingParameters(); index++) {
         string name;

--- a/platforms/reference/src/ReferenceNonbondedSlicingKernels.cpp
+++ b/platforms/reference/src/ReferenceNonbondedSlicingKernels.cpp
@@ -68,8 +68,8 @@ void ReferenceCalcSlicedNonbondedForceKernel::initialize(const System& system, c
         subsets[i] = force.getParticleSubset(i);
 
     set<string> requestedDerivatives;
-    for (int i = 0; i < force.getNumScalingParameterDerivatives(); i++)
-        requestedDerivatives.insert(force.getScalingParameterDerivativeName(i));
+    for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++)
+        requestedDerivatives.insert(force.getEnergyParameterDerivativeName(i));
 
     for (int index = 0; index < force.getNumScalingParameters(); index++) {
         string name;

--- a/python/nonbondedslicing.i
+++ b/python/nonbondedslicing.i
@@ -98,7 +98,7 @@ namespace NonbondedSlicing {
  * can affect multiple slices, and two scaling parameters can affect a single slice, but only if they
  * multiply the Coulomb and Lennard-Jones parts of that slice separately.
  *
- * With :func:`setScalingParameterDerivative`, you can request the derivative with respect to a scaling
+ * With :func:`setEnergyParameterDerivative`, you can request the derivative with respect to a scaling
  * parameter.  All requested derivatives can then be evaluated for a particular :OpenMM:`State` by calling
  * its getEnergyParameterDerivatives_ method.  For this, such State must have been generated from an
  * :OpenMM:`Context` by passing ``True`` to the keyword ``getParameterDerivatives`` of the Context's
@@ -348,8 +348,11 @@ public:
     void setScalingParameter(int index, const std::string& parameter, int subset1, int subset2, bool includeCoulomb, bool includeLJ);
     /**
      * Request the derivative of this Force's energy with respect to a scaling parameter. This
-     * can be used to obtain the sum of particular energy slices. The parameter must have already
-     * been added with :func:`addGlobalParameter` and :func:`addScalingParameter`.
+     * can be used to obtain the value of an energy slice or a sum thereof. The parameter must
+     * have already been added with :func:`addGlobalParameter` and :func:`addScalingParameter`.
+     * Derivatives are only calculated for scaling parameters that multiply the Lennard-Jones
+     * or Coulomb contributions. Requesting the derivative with respect to non-scaling global
+     * parameters will raise an exception.
      *
      * Parameters
      * ----------
@@ -361,11 +364,11 @@ public:
      *     index : int
      *         the index of scaling parameter derivative that was added
      */
-    int addScalingParameterDerivative(const std::string& parameter);
+    int addEnergyParameterDerivative(const std::string& parameter);
     /**
      * Get the number of requested scaling parameter derivatives.
      */
-    int getNumScalingParameterDerivatives() const;
+    int getNumEnergyParameterDerivatives() const;
     /**
      * Get the name of the global parameter associated with a requested scaling parameter
      * derivative.
@@ -374,9 +377,9 @@ public:
      * ----------
      *     index : int
      *         the index of the parameter derivative, between 0 and the result of
-     *         :func:`getNumScalingParameterDerivatives`
+     *         :func:`getNumEnergyParameterDerivatives`
      */
-    const std::string& getScalingParameterDerivativeName(int index) const;
+    const std::string& getEnergyParameterDerivativeName(int index) const;
     /**
      * Set the name of the global parameter to associate with a requested scaling parameter
      * derivative.
@@ -384,11 +387,11 @@ public:
      * Parameters
      * ----------
      *     index : int
-     *         the index of the parameter derivative, between 0 and getNumScalingParameterDerivatives`
+     *         the index of the parameter derivative, between 0 and getNumEnergyParameterDerivatives`
      *     parameter : str
      *         the name of the parameter
      */
-    void setScalingParameterDerivative(int index, const std::string& parameter);
+    void setEnergyParameterDerivative(int index, const std::string& parameter);
 	/**
      * Get whether to use CUDA Toolkit's cuFFT library when executing in the CUDA platform.
      * The default value is `True`.

--- a/python/nonbondedslicing.i
+++ b/python/nonbondedslicing.i
@@ -98,7 +98,7 @@ namespace NonbondedSlicing {
  * can affect multiple slices, and two scaling parameters can affect a single slice, but only if they
  * multiply the Coulomb and Lennard-Jones parts of that slice separately.
  *
- * With :func:`setEnergyParameterDerivative`, you can request the derivative with respect to a scaling
+ * With :func:`addEnergyParameterDerivative`, you can request the derivative with respect to a scaling
  * parameter.  All requested derivatives can then be evaluated for a particular :OpenMM:`State` by calling
  * its getEnergyParameterDerivatives_ method.  For this, such State must have been generated from an
  * :OpenMM:`Context` by passing ``True`` to the keyword ``getParameterDerivatives`` of the Context's
@@ -380,18 +380,6 @@ public:
      *         :func:`getNumEnergyParameterDerivatives`
      */
     const std::string& getEnergyParameterDerivativeName(int index) const;
-    /**
-     * Set the name of the global parameter to associate with a requested scaling parameter
-     * derivative.
-     *
-     * Parameters
-     * ----------
-     *     index : int
-     *         the index of the parameter derivative, between 0 and getNumEnergyParameterDerivatives`
-     *     parameter : str
-     *         the name of the parameter
-     */
-    void setEnergyParameterDerivative(int index, const std::string& parameter);
 	/**
      * Get whether to use CUDA Toolkit's cuFFT library when executing in the CUDA platform.
      * The default value is `True`.

--- a/serialization/src/SlicedNonbondedForceProxy.cpp
+++ b/serialization/src/SlicedNonbondedForceProxy.cpp
@@ -95,9 +95,9 @@ void SlicedNonbondedForceProxy::serialize(const void* object, SerializationNode&
         force.getScalingParameter(i, parameter, subset1, subset2, includeCoulomb, includeLJ);
         scalingParameters.createChildNode("scalingParameter").setStringProperty("parameter", parameter).setIntProperty("subset1", subset1).setIntProperty("subset2", subset2).setBoolProperty("includeCoulomb", includeCoulomb).setBoolProperty("includeLJ", includeLJ);
     }
-    SerializationNode& scalingParameterDerivatives = node.createChildNode("scalingParameterDerivatives");
-    for (int i = 0; i < force.getNumScalingParameterDerivatives(); i++)
-        scalingParameterDerivatives.createChildNode("scalingParameterDerivative").setStringProperty("parameter", force.getScalingParameterDerivativeName(i));
+    SerializationNode& energyParameterDerivatives = node.createChildNode("energyParameterDerivatives");
+    for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++)
+        energyParameterDerivatives.createChildNode("energyParameterDerivative").setStringProperty("parameter", force.getEnergyParameterDerivativeName(i));
 }
 
 void* SlicedNonbondedForceProxy::deserialize(const SerializationNode& node) const {
@@ -150,9 +150,9 @@ void* SlicedNonbondedForceProxy::deserialize(const SerializationNode& node) cons
         const SerializationNode& scalingParameters = node.getChildNode("scalingParameters");
         for (auto& param : scalingParameters.getChildren())
             force->addScalingParameter(param.getStringProperty("parameter"), param.getIntProperty("subset1"), param.getIntProperty("subset2"), param.getBoolProperty("includeCoulomb"), param.getBoolProperty("includeLJ"));
-        const SerializationNode& scalingParameterDerivatives = node.getChildNode("scalingParameterDerivatives");
-        for (auto& param : scalingParameterDerivatives.getChildren())
-            force->addScalingParameterDerivative(param.getStringProperty("parameter"));
+        const SerializationNode& energyParameterDerivatives = node.getChildNode("energyParameterDerivatives");
+        for (auto& param : energyParameterDerivatives.getChildren())
+            force->addEnergyParameterDerivative(param.getStringProperty("parameter"));
     }
     catch (...) {
         delete force;

--- a/serialization/tests/TestSerializeSlicedNonbondedForce.cpp
+++ b/serialization/tests/TestSerializeSlicedNonbondedForce.cpp
@@ -54,7 +54,7 @@ void testSerialization() {
     force.addGlobalParameter("lambda", 0.5);
     force.addScalingParameter("lambda", 0, 1, true, true);
     force.addScalingParameter("lambda", 1, 1, false, true);
-    force.addScalingParameterDerivative("lambda");
+    force.addEnergyParameterDerivative("lambda");
 
     // Serialize and then deserialize it.
 
@@ -163,9 +163,9 @@ void testSerialization() {
         ASSERT_EQUAL(includeLJ1, includeLJ2);
         ASSERT_EQUAL(includeCoulomb1, includeCoulomb2);
     }
-    ASSERT_EQUAL(force.getNumScalingParameterDerivatives(), force2.getNumScalingParameterDerivatives());
-    for (int i = 0; i < force.getNumScalingParameterDerivatives(); i++)
-        ASSERT_EQUAL(force.getScalingParameterDerivativeName(i), force2.getScalingParameterDerivativeName(i))
+    ASSERT_EQUAL(force.getNumEnergyParameterDerivatives(), force2.getNumEnergyParameterDerivatives());
+    for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++)
+        ASSERT_EQUAL(force.getEnergyParameterDerivativeName(i), force2.getEnergyParameterDerivativeName(i))
 }
 
 int main() {

--- a/tests/TestSlicedNonbondedForce.h
+++ b/tests/TestSlicedNonbondedForce.h
@@ -1278,8 +1278,8 @@ void testNonbondedSlicing(OpenMM_SFMT::SFMT& sfmt, NonbondedForce::NonbondedMeth
 
     // Derivatives
 
-    sliced->addScalingParameterDerivative(param01);
-    sliced->addScalingParameterDerivative(param11);
+    sliced->addEnergyParameterDerivative(param01);
+    sliced->addEnergyParameterDerivative(param11);
     context2.reinitialize(true);
     state2 = context2.getState(State::ParameterDerivatives);
     map<string, double> derivatives = state2.getEnergyParameterDerivatives();
@@ -1309,7 +1309,7 @@ void testNonbondedSlicing(OpenMM_SFMT::SFMT& sfmt, NonbondedForce::NonbondedMeth
 
     sliced->addGlobalParameter("remainder", 1.0);
     sliced->addScalingParameter("remainder", 0, 0, includeCoulomb, includeLJ);
-    sliced->addScalingParameterDerivative("remainder");
+    sliced->addEnergyParameterDerivative("remainder");
     context2.reinitialize(true);
     state2 = context2.getState(State::Energy | State::ParameterDerivatives);
     derivatives = state2.getEnergyParameterDerivatives();
@@ -1374,27 +1374,27 @@ void testScalingParameterSeparation(OpenMM_SFMT::SFMT& sfmt, NonbondedForce::Non
     double lambda = 0.5;
     sliced1->addGlobalParameter("lambda", lambda);
     sliced1->addScalingParameter("lambda", 0, 1, true, true);
-    sliced1->addScalingParameterDerivative("lambda");
+    sliced1->addEnergyParameterDerivative("lambda");
     sliced2->addGlobalParameter("lambdaCoulomb", lambda);
     sliced2->addGlobalParameter("lambdaLJ", lambda);
     sliced2->addScalingParameter("lambdaCoulomb", 0, 1, true, false);
     sliced2->addScalingParameter("lambdaLJ", 0, 1, false, true);
-    sliced2->addScalingParameterDerivative("lambdaCoulomb");
-    sliced2->addScalingParameterDerivative("lambdaLJ");
+    sliced2->addEnergyParameterDerivative("lambdaCoulomb");
+    sliced2->addEnergyParameterDerivative("lambdaLJ");
 
     double value = 0.3;
     sliced1->addGlobalParameter("alpha", value);
     sliced1->addScalingParameter("alpha", 0, 0, true, true);
-    sliced1->addScalingParameterDerivative("alpha");
+    sliced1->addEnergyParameterDerivative("alpha");
 
     sliced1->addGlobalParameter("beta", value);
     sliced1->addScalingParameter("beta", 1, 1, true, true);
-    sliced1->addScalingParameterDerivative("beta");
+    sliced1->addEnergyParameterDerivative("beta");
 
     sliced2->addGlobalParameter("gamma", value);
     sliced2->addScalingParameter("gamma", 0, 0, true, true);
     sliced2->addScalingParameter("gamma", 1, 1, true, true);
-    sliced2->addScalingParameterDerivative("gamma");
+    sliced2->addEnergyParameterDerivative("gamma");
 
     system1.addForce(sliced1);
     system2.addForce(sliced2);


### PR DESCRIPTION
## Summary

This PR renames the API methods and attributes related to requesting energy parameter derivatives to align with OpenMM's naming conventions. The changes replace the "ScalingParameterDerivative" terminology with "EnergyParameterDerivative" terminology to better reflect the purpose of these methods and maintain consistency with OpenMM's standard API.

## Changes

### API Method Renames

The following methods have been renamed:

- `getNumScalingParameterDerivatives()` → `getNumEnergyParameterDerivatives()`
- `addScalingParameterDerivative()` → `addEnergyParameterDerivative()`
- `getScalingParameterDerivativeName()` → `getEnergyParameterDerivativeName()`

### API Method Removals

The following method has been removed:

- `setScalingParameterDerivative()` - This method has been removed entirely from the API, as it's not consistent with OpenMM's standard API pattern for energy parameter derivatives.

### Internal Changes

- Renamed internal member variable `scalingParameterDerivatives` → `energyParameterDerivatives`
- Updated all platform implementations (Common and Reference kernels) to use the new method names
- Updated Python SWIG bindings with improved documentation
- Updated serialization code to use the new API

### Documentation Improvements

- Enhanced documentation comments in Python bindings to clarify that:
  - Derivatives can be used to obtain the value of an energy slice or a sum thereof
  - Derivatives are only calculated for scaling parameters that multiply Lennard-Jones or Coulomb contributions
  - Requesting derivatives with respect to non-scaling global parameters will raise an exception

### Other Updates

- Updated copyright year from 2022 to 2022-2025

## Files Changed

- `openmmapi/include/SlicedNonbondedForce.h` - Header file with API declarations
- `openmmapi/src/SlicedNonbondedForce.cpp` - Implementation file
- `platforms/common/src/CommonNonbondedSlicingKernels.cpp` - Common platform implementation
- `platforms/reference/src/ReferenceNonbondedSlicingKernels.cpp` - Reference platform implementation
- `python/nonbondedslicing.i` - Python SWIG bindings
- `serialization/src/SlicedNonbondedForceProxy.cpp` - Serialization code
- `serialization/tests/TestSerializeSlicedNonbondedForce.cpp` - Serialization tests
- `tests/TestSlicedNonbondedForce.h` - C++ test header

## Breaking Changes

⚠️ **This is a breaking change.** Existing code using the old method names will need to be updated:

**Before:**
```cpp
force.addScalingParameterDerivative("lambda");
int num = force.getNumScalingParameterDerivatives();
string name = force.getScalingParameterDerivativeName(0);
```

**After:**
```cpp
force.addEnergyParameterDerivative("lambda");
int num = force.getNumEnergyParameterDerivatives();
string name = force.getEnergyParameterDerivativeName(0);
// Note: setEnergyParameterDerivative() has been removed
```

**Python:**
```python
# Before
force.addScalingParameterDerivative("lambda")
num = force.getNumScalingParameterDerivatives()
force.setScalingParameterDerivative(0, "lambda2")  # This method no longer exists

# After
force.addEnergyParameterDerivative("lambda")
num = force.getNumEnergyParameterDerivatives()
# Note: setEnergyParameterDerivative() has been removed
# To change a derivative, remove it and add a new one instead
```

## Testing

No existing tests have been affected.
